### PR TITLE
[UX] Remove dev image

### DIFF
--- a/installation/docker-amd64-cuda/Dockerfile
+++ b/installation/docker-amd64-cuda/Dockerfile
@@ -112,6 +112,8 @@ COPY dependencies/apt-runtime.txt ${DEPENDENCIES_DIR}/apt-runtime.txt
 COPY dependencies/requirements.txt ${DEPENDENCIES_DIR}/requirements.txt
 
 # Install pip packages.
+# Doing this in the runtime assuming it builds on a base images that has enough build dependencies.
+# Maybe consider doing this in the build stage.
 ARG PIP_REQS_FILE=/tmp/dependencies/requirements.txt
 COPY --link dependencies/requirements.txt ${PIP_REQS_FILE}
 RUN pip freeze > ${DEPENDENCIES_DIR}/requirements-raw-before-pip-install-r.txt
@@ -182,33 +184,6 @@ ENTRYPOINT ["/opt/template-entrypoints/pre-entrypoint.sh"]
 CMD ["/bin/zsh"]
 
 ########################################################################
-# 3. Stages for setting up the user and the development environment.
+# 3. Stages for setting up the user environment.
 # Continued in the Dockerfile-user file.
 ########################################################################
-
-########################################################################
-# Generic layer for development
-
-FROM runtime-generic AS development-generic
-
-# Install development packages.
-
-# Enable caching for `apt` packages in Docker.
-# https://docs.docker.com/engine/reference/builder/#run---mounttypecache
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > \
-    /etc/apt/apt.conf.d/keep-cache
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG DEV_DEPENDENCIES_FILE=/tmp/dependencies/apt-dev.txt
-COPY --link dependencies/apt-dev.txt ${DEV_DEPENDENCIES_FILE}
-
-# sed is only used as a hack to remove comments from the file apt-dev.txt.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/var/lib/apt,sharing=private \
-    apt update && \
-    sed -e 's/#.*//g' -e 's/\r//g' ${DEV_DEPENDENCIES_FILE} | \
-    xargs -t apt-get install -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY dependencies/apt-dev.txt ${DEPENDENCIES_DIR}/apt-dev.txt

--- a/installation/docker-amd64-cuda/Dockerfile-user
+++ b/installation/docker-amd64-cuda/Dockerfile-user
@@ -10,7 +10,7 @@ ARG IMAGE_PLATFORM
 # Explicitly create a user for Docker Engine interfaces
 # which do no support selecting the user at runtime; this is the case for Run:ai.
 
-FROM ${GENERIC_IMAGE}:${IMAGE_PLATFORM}-run-latest-root AS runtime-user
+FROM ${GENERIC_IMAGE}:${IMAGE_PLATFORM}-root-latest AS runtime-user
 
 ARG GRPID
 ARG USRID
@@ -30,7 +30,7 @@ RUN touch /home/${USR}/.zshrc
 ########################################################################
 # Final development layer for the user.
 
-FROM ${GENERIC_IMAGE}:${IMAGE_PLATFORM}-dev-latest-root AS development-user
+FROM ${GENERIC_IMAGE}:${IMAGE_PLATFORM}-root-latest AS development-user
 
 ARG GRPID
 ARG USRID

--- a/installation/docker-amd64-cuda/EPFL-runai-setup/README.md
+++ b/installation/docker-amd64-cuda/EPFL-runai-setup/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-At this point, you should have runtime and development images that can be deployed on multiple platforms.
-This guide will show you how to deploy your images on the EPFL IC and RCP Run:ai clusters and use them for:
+At this point, you should have the runtime image that can be deployed on multiple platforms.
+This guide will show you how to deploy your image on the EPFL IC and RCP Run:ai clusters and use it for:
 
 1. Remote development. (At CLAIRE, we use the Run:ai platform as our daily driver.)
 2. Running unattended jobs.
@@ -16,7 +16,7 @@ instructions in the `installation/docker-amd64-cuda/README.md` file.
 
 **Docker image**:
 
-You should be able to run your Docker images locally
+You should be able to run your Docker image locally
 (e.g., on the machine you built it, or for CLAIRE with the remote Docker Engine on our `claire-build-machine`).
 It will be hard to debug your image on Run:ai if you can't even run it locally.
 The simple checks below will be enough.
@@ -61,14 +61,12 @@ They will be in `.EPFL-runai-setup/submit-scripts`.
 
 ### Push your image to the RCP or IC Docker registry
 
-The following will push the generic and user-configured runtime and development images.
+The following will push the generic and user-configured runtime images.
 
-- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-run-latest-root`
-- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-dev-latest-root`
-- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-run-latest-USR`
-- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-dev-latest-USR`
+- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-root-latest`
+- `LAB_NAME/USR/PROJECT_NAME:PLATFORM-USR-latest`
 
-It will also push them with the git commit hash as a tag if no new commit was made since the last build.
+It will also push them with the git commit hash as a tag if the build is at the latest commit.
 You can rebuild the images with `./template.sh build` to tag them with the latest commit hash.
 
 ```bash

--- a/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/first-steps.sh
+++ b/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/first-steps.sh
@@ -1,7 +1,7 @@
 runai submit \
   --name example-first-steps \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-dev-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   -e SSH_SERVER=1 \
   -- sleep infinity
@@ -14,9 +14,6 @@ runai submit \
 # we recommend always mounting it inside the / directory always with the same name.
 # 2. the environment variables that configure the entrypoint.
 # -e SSH_SERVER=1 will make the entrypoint start an ssh server.
-
-# Also note that here we are using the dev image (dev-latest-moalla)
-# which contains the dependencies to open the ssh server.
 
 ## Useful commands.
 # runai describe job example-first-steps

--- a/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/minimal.sh
+++ b/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/minimal.sh
@@ -1,7 +1,7 @@
 runai submit \
   --name example-minimal \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-run-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/dev \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/dev \
@@ -19,10 +19,6 @@ runai submit \
 # -e PROJECT_ROOT_AT=<location of your project in your mounted PVC> .
 # 3.The working directory set to the PROJECT_ROOT_AT.
 # --working-dir same as PROJECT_ROOT_AT.
-
-# Note that here we are using the run image (run-latest-moalla)
-# There is no need to use the dev images when not planning to develop in the container.
-# The run image is typically smaller and can be scaled to run multiple jobs.
 
 ## Useful commands.
 # runai describe job example-minimal

--- a/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/remote-development.sh
+++ b/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/remote-development.sh
@@ -9,7 +9,7 @@
 runai submit \
   --name example-remote-development \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-dev-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/dev \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/dev \
@@ -23,7 +23,7 @@ runai submit \
 runai submit \
   --name example-remote-development \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-dev-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/dev \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/dev \
@@ -41,7 +41,7 @@ runai submit \
 runai submit \
   --name example-remote-development \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-dev-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/dev \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/dev \
@@ -58,7 +58,7 @@ runai submit \
 runai submit \
   --name example-remote-development \
   --interactive \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-dev-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/dev \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/dev \

--- a/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/unattended.sh
+++ b/installation/docker-amd64-cuda/EPFL-runai-setup/template-submit-examples/unattended.sh
@@ -1,6 +1,6 @@
 runai submit \
   --name example-unattended \
-  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-run-latest-moalla \
+  --image registry.rcp.epfl.ch/claire/moalla/template-project-name:amd64-cuda-moalla-latest \
   --pvc runai-claire-moalla-scratch:/claire-rcp-scratch \
   --working-dir /claire-rcp-scratch/home/moalla/template-project-name/run \
   -e PROJECT_ROOT_AT=/claire-rcp-scratch/home/moalla/template-project-name/run \

--- a/installation/docker-amd64-cuda/compose-base.yaml
+++ b/installation/docker-amd64-cuda/compose-base.yaml
@@ -1,5 +1,5 @@
 services:
-  args-run-root:
+  build-args:
     build:
       args:
         # Pytorch 2.4.0a0+f70bd71a48, NVIDIA CUDA 12.5.0.23, Python 3.10.

--- a/installation/docker-amd64-cuda/compose.yaml
+++ b/installation/docker-amd64-cuda/compose.yaml
@@ -1,9 +1,9 @@
 services:
-  image-run-root:
+  image-root:
     extends:
       file: compose-base.yaml
-      service: args-run-root
-    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-run-latest-root
+      service: build-args
+    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-root-latest
     build:
       platforms:
         - "linux/amd64"
@@ -14,18 +14,10 @@ services:
         PROJECT_NAME: ${PROJECT_NAME}
         PACKAGE_NAME: ${PACKAGE_NAME}
 
-  image-dev-root:
+  image-user:
     extends:
-      service: image-run-root
-    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-dev-latest-root
-    build:
-      dockerfile: Dockerfile
-      target: development-generic
-
-  image-run-user:
-    extends:
-      service: image-run-root
-    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-run-latest-${USR}
+      service: image-root
+    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-${USR}-latest
     build:
       dockerfile: Dockerfile-user
       target: runtime-user
@@ -38,16 +30,9 @@ services:
         USR: ${USR}
         PASSWD: ${PASSWD}
 
-  image-dev-user: # Service to build the development image.
-    extends:
-      service: image-run-user
-    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-dev-latest-${USR}
-    build:
-      target: development-user
-
   run-local-cpu: # Service to run the image locally with CPU only.
     extends:
-      service: image-run-user
+      service: image-user
     tty: true
     stdin_open: true
     volumes:
@@ -66,7 +51,6 @@ services:
   dev-local-cpu: # Service to develop locally with CPU only.
     extends:
       service: run-local-cpu
-    image: ${IMAGE_NAME}:${IMAGE_PLATFORM}-dev-latest-${USR}
     volumes:
       # To persist IDE settings and cache.
       - ${HOME}/.template-gitconfig:/home/${USR}/.gitconfig

--- a/installation/docker-amd64-cuda/dependencies/apt-dev.txt
+++ b/installation/docker-amd64-cuda/dependencies/apt-dev.txt
@@ -1,7 +1,0 @@
-# `apt` development requirements file.
-# Installed in addition to the runtime requirements file.
-# These dependencies must not be required to run your code in a non-interactive session.
-# They will not be available in the runtime image.
-# They should only help in the interactive development images.
-openssh-server  # Required for remote development with most IDEs.
-sudo            # Recommended.

--- a/installation/docker-amd64-cuda/dependencies/apt-runtime.txt
+++ b/installation/docker-amd64-cuda/dependencies/apt-runtime.txt
@@ -2,6 +2,8 @@
 # These dependencies are required to run your code.
 zsh                 # Required.
 openssl             # Required.
+openssh-server      # Required for remote development with most IDEs.
+sudo                # Required to open ssh server.
 ca-certificates     # Useful.
 htop                # Useful.
 git                 # Useful.

--- a/installation/docker-amd64-cuda/from-python-template/Dockerfile
+++ b/installation/docker-amd64-cuda/from-python-template/Dockerfile
@@ -112,6 +112,8 @@ COPY dependencies/apt-runtime.txt ${DEPENDENCIES_DIR}/apt-runtime.txt
 COPY dependencies/requirements.txt ${DEPENDENCIES_DIR}/requirements.txt
 
 # Install pip packages.
+# Doing this in the runtime assuming it builds on a base images that has enough build dependencies.
+# Maybe consider doing this in the build stage.
 ARG PIP_REQS_FILE=/tmp/dependencies/requirements.txt
 COPY --link dependencies/requirements.txt ${PIP_REQS_FILE}
 RUN pip freeze > ${DEPENDENCIES_DIR}/requirements-raw-before-pip-install-r.txt
@@ -182,33 +184,6 @@ ENTRYPOINT ["/opt/template-entrypoints/pre-entrypoint.sh"]
 CMD ["/bin/zsh"]
 
 ########################################################################
-# 3. Stages for setting up the user and the development environment.
+# 3. Stages for setting up the user environment.
 # Continued in the Dockerfile-user file.
 ########################################################################
-
-########################################################################
-# Generic layer for development
-
-FROM runtime-generic AS development-generic
-
-# Install development packages.
-
-# Enable caching for `apt` packages in Docker.
-# https://docs.docker.com/engine/reference/builder/#run---mounttypecache
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > \
-    /etc/apt/apt.conf.d/keep-cache
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG DEV_DEPENDENCIES_FILE=/tmp/dependencies/apt-dev.txt
-COPY --link dependencies/apt-dev.txt ${DEV_DEPENDENCIES_FILE}
-
-# sed is only used as a hack to remove comments from the file apt-dev.txt.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/var/lib/apt,sharing=private \
-    apt update && \
-    sed -e 's/#.*//g' -e 's/\r//g' ${DEV_DEPENDENCIES_FILE} | \
-    xargs -t apt-get install -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY dependencies/apt-dev.txt ${DEPENDENCIES_DIR}/apt-dev.txt

--- a/installation/docker-amd64-cuda/from-python-template/apt-dev.txt
+++ b/installation/docker-amd64-cuda/from-python-template/apt-dev.txt
@@ -1,7 +1,0 @@
-# `apt` development requirements file.
-# Installed in addition to the runtime requirements file.
-# These dependencies must not be required to run your code in a non-interactive session.
-# They will not be available in the runtime image.
-# They should only help in the interactive development images.
-openssh-server  # Required for remote development with most IDEs.
-sudo            # Recommended.

--- a/installation/docker-amd64-cuda/from-python-template/apt-runtime.txt
+++ b/installation/docker-amd64-cuda/from-python-template/apt-runtime.txt
@@ -2,6 +2,8 @@
 # These dependencies are required to run your code.
 zsh                 # Required.
 openssl             # Required.
+openssh-server      # Required for remote development with most IDEs.
+sudo                # Required to open ssh server.
 ca-certificates     # Useful.
 htop                # Useful.
 git                 # Useful.

--- a/installation/docker-amd64-cuda/from-python-template/compose-base.yaml
+++ b/installation/docker-amd64-cuda/from-python-template/compose-base.yaml
@@ -1,5 +1,5 @@
 services:
-  args-run-root:
+  build-args:
     build:
       args:
         # Pytorch 2.4.0a0+f70bd71a48, NVIDIA CUDA 12.5.0.23, Python 3.10.

--- a/installation/docker-amd64-cuda/from-scratch-template/Dockerfile
+++ b/installation/docker-amd64-cuda/from-scratch-template/Dockerfile
@@ -233,33 +233,6 @@ ENTRYPOINT ["/opt/template-entrypoints/pre-entrypoint.sh"]
 CMD ["/bin/zsh"]
 
 ########################################################################
-# 3. Stages for setting up the user and the development environment.
+# 3. Stages for setting up the user environment.
 # Continued in the Dockerfile-user file.
 ########################################################################
-
-########################################################################
-# Generic layer for development
-
-FROM runtime-generic AS development-generic
-
-# Install development packages.
-
-# Enable caching for `apt` packages in Docker.
-# https://docs.docker.com/engine/reference/builder/#run---mounttypecache
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > \
-    /etc/apt/apt.conf.d/keep-cache
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG DEV_DEPENDENCIES_FILE=/tmp/dependencies/apt-dev.txt
-COPY --link dependencies/apt-dev.txt ${DEV_DEPENDENCIES_FILE}
-
-# sed is only used as a hack to remove comments from the file apt-dev.txt.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/var/lib/apt,sharing=private \
-    apt update && \
-    sed -e 's/#.*//g' -e 's/\r//g' ${DEV_DEPENDENCIES_FILE} | \
-    xargs -t apt-get install -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY dependencies/apt-dev.txt ${DEPENDENCIES_DIR}/apt-dev.txt

--- a/installation/docker-amd64-cuda/from-scratch-template/apt-dev.txt
+++ b/installation/docker-amd64-cuda/from-scratch-template/apt-dev.txt
@@ -1,7 +1,0 @@
-# `apt` development requirements file.
-# Installed in addition to the runtime requirements file.
-# These dependencies must not be required to run your code in a non-interactive session.
-# They will not be available in the runtime image.
-# They should only help in the interactive development images.
-openssh-server  # Required for remote development with most IDEs.
-sudo            # Recommended.

--- a/installation/docker-amd64-cuda/from-scratch-template/apt-runtime.txt
+++ b/installation/docker-amd64-cuda/from-scratch-template/apt-runtime.txt
@@ -2,6 +2,8 @@
 # These dependencies are required to run your code.
 zsh                 # Required.
 openssl             # Required.
+openssh-server      # Required for remote development with most IDEs.
+sudo                # Required to open ssh server.
 ca-certificates     # Useful.
 htop                # Useful.
 git                 # Useful.

--- a/installation/docker-amd64-cuda/from-scratch-template/compose-base.yaml
+++ b/installation/docker-amd64-cuda/from-scratch-template/compose-base.yaml
@@ -1,5 +1,5 @@
 services:
-  args-run-root:
+  build-args:
     build:
       args:
         BASE_IMAGE: ubuntu:22.04                # Ubuntu: https://hub.docker.com/_/ubuntu


### PR DESCRIPTION
There isn't much size difference between the run and dev images in general, especially with NGC images.
Remove this extra layer of complexity to simplify the user experience.